### PR TITLE
update docs; merge fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,7 @@ You can access individual building blocks too:
 import {
   generatePortableHTML,
   generateRecursivePortableHTML,
-  bundleMultiPageHTML,
-  fetchAndPackWebPage,
+  bundleMultiPageHTML
 } from 'portapack';
 ```
 
@@ -105,7 +104,6 @@ import {
 | --------------------------------- | ------------------------------------- |
 | `generatePortableHTML()`          | Bundle a single file or URL           |
 | `generateRecursivePortableHTML()` | Crawl & bundle entire site            |
-| `fetchAndPackWebPage()`           | Just fetch HTML (no asset processing) |
 | `bundleMultiPageHTML()`           | Combine multiple HTMLs with router    |
 
 ## 📊 Project Health

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,8 +77,7 @@ For more specific use cases, you can access individual components:
 import {
   generatePortableHTML,
   generateRecursivePortableHTML,
-  bundleMultiPageHTML,
-  fetchAndPackWebPage,
+  bundleMultiPageHTML
 } from 'portapack';
 
 // Bundle a single HTML file or URL


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update README.md and getting-started.md to remove references to deprecated functions `fetchAndPackWebPage()`