### PR TITLE
fix: typo in link

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -52,7 +52,7 @@ export default defineConfig({
         ],
       },
       { text: 'Contributing', link: '/contributing' },
-      { text: 'Archiecture', link: '/architecture'},
+      { text: 'Architecture', link: '/architecture'},
       { text: 'Roadmap', link: 'roadmap'}
     ],
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Corrected the spelling of 'Architecture' in the VitePress configuration sidebar menu